### PR TITLE
Fix clang pre-processor issue

### DIFF
--- a/src/Generics/Generic/Aeson.hs
+++ b/src/Generics/Generic/Aeson.hs
@@ -10,8 +10,7 @@
   , TupleSections
   , TypeOperators
   , TypeSynonymInstances
-  , InstanceSigs
-  #-}
+  , InstanceSigs #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | This module offers generic conversions to an from JSON 'Value's
 -- for data types with a 'Generic' instance.


### PR DESCRIPTION
I noticed this when trying to do `cabal install rest-core`. Similar to https://github.com/bos/aeson/issues/154, this fixes the following error when installing generic-aeson:

```
Preprocessing library generic-aeson-0.1.0.3...

src/Generics/Generic/Aeson.hs:14:4:
     error: invalid preprocessing directive
      #-}
       ^
```

I'm using

```
$ clang --version
Apple LLVM version 5.1 (clang-503.0.38) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.1.0
Thread model: posix
```
